### PR TITLE
fix: Correct chord display and text output

### DIFF
--- a/main/app-midi-export.js
+++ b/main/app-midi-export.js
@@ -44,8 +44,13 @@ function buildSongDataForTextFile() {
 
     sections.forEach(sectionData => {
         songDataText += `\n${sectionData.name.toUpperCase()} (${sectionData.measures} bars in ${sectionData.timeSignature[0]}/${sectionData.timeSignature[1]})\n`;
-        if (sectionData.baseChords && sectionData.baseChords.length > 0) {
-            songDataText += `Chords: [ ${sectionData.baseChords.join(' | ')} ]\n`;
+        if (sectionData.mainChordSlots && sectionData.mainChordSlots.length > 0) {
+            const ticksPerBeat = (4 / sectionData.timeSignature[1]) * TPQN_TEXT;
+            const chordsWithDuration = sectionData.mainChordSlots.map(slot => {
+                const durationInBeats = (slot.effectiveDurationTicks / ticksPerBeat).toFixed(2).replace(/\.00$/, '');
+                return `${slot.chordName} (${durationInBeats} beats)`;
+            });
+            songDataText += `Chords: [ ${chordsWithDuration.join(' | ')} ]\n`;
         }
     });
     currentSongDataForSave = {title: title, content: songDataText};

--- a/main/app-ui-render.js
+++ b/main/app-ui-render.js
@@ -135,21 +135,13 @@ async function renderSongOutput(songData, allGeneratedChordsSet, styleNote, main
         output += `  <div class="section-card-header">${sectionTitleForDisplay}</div>`;
         output += `  <div class="section-card-body">`;
         output += `    <div class="section-card-chords-container">`;
-
-        if (sectionData.mainChordSlots && sectionData.mainChordSlots.length > 0) {
-            const totalTicks = sectionData.measures * (4 / sectionData.timeSignature[1]) * TICKS_PER_QUARTER_NOTE_REFERENCE;
-            sectionData.mainChordSlots.forEach(slot => {
-                const widthPercentage = (slot.effectiveDurationTicks / totalTicks) * 100;
-                output += `<div class="section-card-chord-slot" style="width: ${widthPercentage}%;" title="${slot.chordName}"><span>${slot.chordName}</span></div>`;
-            });
-        } else {
-            output += `<div class="section-card-chords" data-has-chords="false">(Instrumental/Silence)</div>`;
-        }
-
+        const chordsString = sectionData.mainChordSlots && sectionData.mainChordSlots.length > 0
+            ? sectionData.mainChordSlots.map(slot => slot.chordName).join(' | ')
+            : '(Instrumental/Silence)';
+        output += `      <div class="section-card-chords" data-chords="${chordsString}" data-has-chords="${!!(sectionData.mainChordSlots && sectionData.mainChordSlots.length > 0)}">${chordsString}</div>`;
         output += `    </div>`;
         output += `    <div class="section-bars-label">${barCountActual} bars</div>`;
         output += `  </div>`;
-        // La griglia delle barre rimane per riferimento visivo, ma gli accordi ora sono indipendenti
         output += `  <div class="section-bar-grid" data-bar-count="${barCountActual}"></div>`;
         output += `</div>`;
     });

--- a/style/components.css
+++ b/style/components.css
@@ -225,53 +225,26 @@ button#generateButton:disabled {
 }
 
 .timeline-section-card .section-card-chords-container {
-    display: flex;
-    width: 100%;
-    height: 30px; /* Altezza fissa per la riga degli accordi */
-    background-color: rgba(0,0,0,0.1);
-    border-radius: 3px;
-    overflow: hidden;
     margin-bottom: var(--space-xs);
 }
 
-.section-card-chord-slot {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    box-sizing: border-box;
-    border-right: 1px solid rgba(0,0,0,0.2);
+.timeline-section-card .section-card-chords-label {
+    font-weight: bold;
+    font-size: 14px;
+    display: block;
+    margin-bottom: 2px;
+    opacity: 0.8;
+    color: inherit;
+}
+
+.timeline-section-card .section-card-chords {
     font-family: var(--font-monospace);
     font-size: 14px;
+    white-space: pre-wrap; /* Permette al testo di andare a capo */
+    word-break: normal;
+    line-height: 1.3;
     color: inherit;
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding: 0 4px;
-}
-
-.section-card-chord-slot:last-child {
-    border-right: none;
-}
-
-.section-card-chord-slot span {
-    display: inline-block;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* Vecchie regole per .section-card-chords e label, potrebbero essere rimosse o mantenute per fallback */
-.timeline-section-card .section-card-chords-label {
-  font-weight: bold; font-size: 14px; display: block;
-  margin-bottom: 2px; opacity: 0.8; color: inherit;
-}
-.timeline-section-card .section-card-chords {
-  font-family: var(--font-monospace); font-size: 14px;
-  white-space: pre-wrap; word-break: normal; line-height: 1.3;
-  color: inherit; margin-bottom: var(--space-xs);
+    margin-bottom: var(--space-xs);
 }
 
 .timeline-section-card .section-bar-grid {


### PR DESCRIPTION
This commit addresses several issues related to the new dynamic harmony engine:

- **Fix Chord Truncation:** Reverted CSS changes to allow chord text to wrap in the timeline, preventing truncation in shorter sections.
- **Fix UI Chord Count:** The timeline UI now correctly displays the variable number of chords by building the display string from `mainChordSlots` instead of `baseChords`.
- **Enhance Text File Output:** The generated text file now includes the accurate list of chords per section and specifies the duration of each chord in beats, providing a more detailed and accurate summary of the song structure.